### PR TITLE
fix problem for licenses with no html representation

### DIFF
--- a/src/main/java/resus/licenseengine/utils/LicenseUtils.java
+++ b/src/main/java/resus/licenseengine/utils/LicenseUtils.java
@@ -193,11 +193,16 @@ public class LicenseUtils {
 	public static String getLicenseTextHtml(String licenseID) {
 
 		logger.debug("Returning the text as html for the license: {}...", licenseID);
+		SpdxListedLicense license = null;
 
 		try {
-			return listedLicenses.getListedLicenseById(licenseID).getLicenseTextHtml();
+			license = listedLicenses.getListedLicenseById(licenseID);
+			return license.getLicenseTextHtml();
 		} catch (InvalidLicenseTemplateException | InvalidSPDXAnalysisException e) {
 			logger.warn("Can't find license with ID: {}", licenseID);
+		} catch (ArrayIndexOutOfBoundsException e) {
+			logger.warn("The license with ID: {} has no HTML representation. Returning plain text instead.", licenseID);
+			return license.getLicenseText();
 		}
 		return null;
 	}


### PR DESCRIPTION
Some licenses have no HTML representation. In these cases, the plain license text should be returned instead.